### PR TITLE
Allows to build plugin as independent package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 ##---------------------------------------------------------------------------
 ## Author:      nohal aka. Pavel Kalian
-## Copyright:   
+## Copyright:
 ## License:     wxWidgets License
 ##---------------------------------------------------------------------------
- 
+
 # define minimum cmake version
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6.2)
 IF(NOT APPLE) #wxCTB not known to work on Mac
@@ -45,16 +45,20 @@ IF(WIN32)
     ADD_DEFINITIONS(-D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE)
 ENDIF(WIN32)
 
+IF(UNIX AND NOT APPLE)
+  SET(PREFIX_PLUGINS /usr/lib/opencpn)
+  SET(PREFIX_DATA /usr/share)
+ENDIF(UNIX AND NOT APPLE)
 
-#SET(wxWidgets_USE_LIBS base core net xml html adv)
-#SET(BUILD_SHARED_LIBS TRUE)
-#FIND_PACKAGE(wxWidgets REQUIRED)
+SET(wxWidgets_USE_LIBS base core net xml html adv)
+SET(BUILD_SHARED_LIBS TRUE)
+FIND_PACKAGE(wxWidgets REQUIRED)
 
 INCLUDE(${wxWidgets_USE_FILE})
 
 FIND_PACKAGE(Gettext REQUIRED)
 
-# For convenience we define the sources as a variable. You can add 
+# For convenience we define the sources as a variable. You can add
 # header files and cpp/c files and CMake will sort them out
 
 SET(SRC_OCPNDEBUGGER
@@ -89,7 +93,7 @@ ENDIF(UNIX AND NOT APPLE)
 IF(WIN32)
 INSTALL(TARGETS ${PACKAGE_NAME} RUNTIME DESTINATION "plugins")
 ENDIF(WIN32)
- 	  	 
+
 # find src/ -name \*.cpp -or -name \*.c -or -name \*.h -or -name \*.hpp >po/POTFILES.in
 FIND_PROGRAM(GETTEXT_XGETTEXT_EXECUTABLE xgettext)
 IF (GETTEXT_XGETTEXT_EXECUTABLE)

--- a/src/ocpndebugger_pi.h
+++ b/src/ocpndebugger_pi.h
@@ -42,7 +42,7 @@
 #define     MY_API_VERSION_MAJOR    1
 #define     MY_API_VERSION_MINOR    8
 
-#include "../../../include/ocpn_plugin.h"
+#include <opencpn/ocpn_plugin.h>
 
 #include "ocpndebuggergui_impl.h"
 
@@ -62,7 +62,7 @@ public:
 //    The required PlugIn Methods
       int Init(void);
       bool DeInit(void);
-      
+
       int GetAPIVersionMajor();
       int GetAPIVersionMinor();
       int GetPlugInVersionMajor();


### PR DESCRIPTION
Hi,

I recently created a devel package for OpenCPN, so that plugins can be built separatly.
I patch yours, hope you'll enjoy it.

Please, see the [wiki page](https://en.opensuse.org/OpenCPN-build-plugins) and the [build page](https://build.opensuse.org/project/show/home:OrbitalRio:branches:Application:Geo:OpenCPN:head), where the OpenCPN-devel package is.
